### PR TITLE
Tweak rack monitor setup

### DIFF
--- a/apps/main/system/main/application.rb
+++ b/apps/main/system/main/application.rb
@@ -24,11 +24,6 @@ module Main
       end
     end
 
-    error do |e|
-      self.class[:rack_monitor].instrument(:error, exception: e)
-      raise e
-    end
-
     load_routes!
   end
 end

--- a/apps/main/system/main/container.rb
+++ b/apps/main/system/main/container.rb
@@ -6,8 +6,6 @@ module Main
     require root.join("system/blog/container")
     import core: Blog::Container
 
-    register :rack_monitor, Blog::Container[:rack_monitor]
-
     configure do |config|
       config.root = Pathname(__FILE__).join("../..").realpath.dirname.freeze
       config.logger = Blog::Container[:logger]


### PR DESCRIPTION
Address an issue that was leading to web requests being logged twice. This will also be fixed in the upstream dry-web-roda project generator.