### PR TITLE
.gitignore .ruby-gemset .ruby-version db/structure.sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # Temp files
 tmp/*
+
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
Files .ruby-gemset/version comes from rvm(Ruby version manager).
`rake db:migrate` updates `db/structure.sql`, it makes sense to .gitignore it.