### PR TITLE
Travis: Drop unused Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 dist: trusty
-sudo: false
 cache: bundler
 before_script:
   - cp .example.env-travis .env


### PR DESCRIPTION
This PR removes a now-unused piece of Travis configuration.


See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
